### PR TITLE
Support for passReqToCallback option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,25 @@ passport.use(new RavenStrategy({
  - `desc` (String) - a description of the website to be displayed on the raven login page
  - `msg` (String) - a description of why authentication is being requested
  - `iact` (Boolean) - Set to `true` to force users to type their username and password even if they are already logged in. Set to `false` to only login if it can be done without user interaction.  Defaults to `null`.
+ - `passReqToCallback` (Boolean) - If set the request object is provided as the first argument to the verify function. The verify callback can therefor euse the state of the request to tailer further handling.
+
+
+```js
+
+passport.use(new RavenStrategy({
+  desc: 'My Raven Application',
+  msg: 'we need to check you are a current student',
+  // use demonstration raven server in development
+  debug: process.env.NODE_ENV !== 'production',
+  passReqToCallback : true
+}, function (req,crsid, params, callback) {
+  // this function could be defined elsewhere eg in a Sails app services protocol
+     ....
+  }
+});
+`
+
+```
 
 **Params:**
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ passport.use(new RavenStrategy({
  - `desc` (String) - a description of the website to be displayed on the raven login page
  - `msg` (String) - a description of why authentication is being requested
  - `iact` (Boolean) - Set to `true` to force users to type their username and password even if they are already logged in. Set to `false` to only login if it can be done without user interaction.  Defaults to `null`.
- - `passReqToCallback` (Boolean) - If set the request object is provided as the first argument to the verify function. The verify callback can therefor euse the state of the request to tailer further handling.
+ - `passReqToCallback` (Boolean) - If set the request object is provided as the first argument to the verify function. The verify callback can therefore use the state of the request to tailer further handling.
 
 
 ```js
@@ -56,7 +56,7 @@ passport.use(new RavenStrategy({
   // use demonstration raven server in development
   debug: process.env.NODE_ENV !== 'production',
   passReqToCallback : true
-}, function (req,crsid, params, callback) {
+}, function (req, crsid, params, callback) {
   // this function could be defined elsewhere eg in a Sails app services protocol
      ....
   }

--- a/index.js
+++ b/index.js
@@ -108,17 +108,17 @@ Strategy.prototype.processResponse = function (req) {
         debug('Raven response signature check passed.');
         response.isCurrent = response.ptags === 'current';
         if (self._opts['passReqToCallback']) {
-        	return self._verify(req,response.principal, response, function (err, user, info) {
-        	  if (err) { return self.error(err); }
-        	  if (!user) { return self.fail(info); }
-        	  self.success(user, info);
-        	});
+          return self._verify(req, response.principal, response, function (err, user, info) {
+            if (err) { return self.error(err); }
+            if (!user) { return self.fail(info); }
+            self.success(user, info);
+          });
 	}else{
-                return self._verify(response.principal, response, function (err, user, info) {
-                  if (err) { return self.error(err); }
-                  if (!user) { return self.fail(info); }
-                  self.success(user, info);
-                });
+          return self._verify(response.principal, response, function (err, user, info) {
+            if (err) { return self.error(err); }
+            if (!user) { return self.fail(info); }
+            self.success(user, info);
+          });
 	}
       } else {
         debug('Raven response signature check failed.');

--- a/index.js
+++ b/index.js
@@ -107,11 +107,19 @@ Strategy.prototype.processResponse = function (req) {
       if (checkSignature(data, response.sig, this.debug ? KEYS.debug : KEYS.production)) {
         debug('Raven response signature check passed.');
         response.isCurrent = response.ptags === 'current';
-        return self._verify(response.principal, response, function (err, user, info) {
-          if (err) { return self.error(err); }
-          if (!user) { return self.fail(info); }
-          self.success(user, info);
-        });
+        if (self._opts['passReqToCallback']) {
+        	return self._verify(req,response.principal, response, function (err, user, info) {
+        	  if (err) { return self.error(err); }
+        	  if (!user) { return self.fail(info); }
+        	  self.success(user, info);
+        	});
+	}else{
+                return self._verify(response.principal, response, function (err, user, info) {
+                  if (err) { return self.error(err); }
+                  if (!user) { return self.fail(info); }
+                  self.success(user, info);
+                });
+	}
       } else {
         debug('Raven response signature check failed.');
         return this.error(new Error('Raven response signature check failed.'));

--- a/index.js
+++ b/index.js
@@ -113,13 +113,13 @@ Strategy.prototype.processResponse = function (req) {
             if (!user) { return self.fail(info); }
             self.success(user, info);
           });
-	}else{
+        } else {
           return self._verify(response.principal, response, function (err, user, info) {
             if (err) { return self.error(err); }
             if (!user) { return self.fail(info); }
             self.success(user, info);
           });
-	}
+        }
       } else {
         debug('Raven response signature check failed.');
         return this.error(new Error('Raven response signature check failed.'));

--- a/test/server.js
+++ b/test/server.js
@@ -5,7 +5,7 @@ var passport = require('passport');
 var Raven = require('../');
 
 passport.use(new Raven({
-  audience: process.env.test_audience || 'http://localhost:3000',
+  audience: 'http://localhost:3000',
   desc: 'Passport Raven Demo',
   msg: 'Login to demonstrate logging in to a node.js app using passport-raven',
   debug: false

--- a/test/server.js
+++ b/test/server.js
@@ -5,7 +5,7 @@ var passport = require('passport');
 var Raven = require('../');
 
 passport.use(new Raven({
-  audience: 'http://localhost:3000',
+  audience: process.env.test_audience || 'http://localhost:3000',
   desc: 'Passport Raven Demo',
   msg: 'Login to demonstrate logging in to a node.js app using passport-raven',
   debug: false


### PR DESCRIPTION
Dear Forbes,

(I'm sure the if statement could be written a little more succinctly. )

Whilst attempting to try out your passport-raven module in a Sails application I needed to access the request during the callback.  I noticed that there was an option I could set (passReqToCallback) but your modules didn't currently support it.  I added in here so hopefully it can now provide this feature.

The change to the test script sadly does not include a test for this change bu the ability to test the system from another host rather than localhost (I've no GUI on my dev machine).

I'd be grateful if you could consider these changes.  I'm, hopefully, intending to use them

Thanks in advance,
Stephen
